### PR TITLE
Include private posts when fetching user posts.

### DIFF
--- a/reckoning.php
+++ b/reckoning.php
@@ -111,7 +111,7 @@ function display_reckoning_admin_page_individual( $user ) {
 	global $wpdb;
 	$blog = get_blog_details();
 	$comments = get_comments( array( 'user_id' => $user->data->ID ) );
-	$posts = get_posts( array( 'author' => $user->data->ID , 'numberposts' => '-1' ) );
+	$posts = get_posts( array( 'author' => $user->data->ID , 'numberposts' => '-1', 'post_status' => array( 'publish', 'private' ) ) );
 ?>
 	<div class="wrap">
 	<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
@@ -200,7 +200,7 @@ function display_reckoning_admin_page_all() {
 
 	// Start looping through each user.
 	foreach ( $users as $user ) :
-		$posts = get_posts( array( 'author' => $user->data->ID, 'numberposts' => '-1' ) );
+		$posts = get_posts( array( 'author' => $user->data->ID, 'numberposts' => '-1', 'post_status' => array( 'publish', 'private' ) ) );
 		$comments = get_comments( array( 'user_id' => $user->data->ID ) );
 
 		// Show the username with a link to a more detailed view of the user.


### PR DESCRIPTION
Hi Shawn - We're using this plugin on the CUNY Academic Commons, and found it limiting that 'private' posts are not available. This PR rectifies that.